### PR TITLE
Reorder the gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,8 +4,8 @@ node_modules
 /.svelte-kit
 /package
 .env
-/prisma/dev.db
 .env.*
 !.env.example
 vite.config.js.timestamp-*
 vite.config.ts.timestamp-*
+/prisma/dev.db


### PR DESCRIPTION
Reorder the gitignore, move `/prisma/dev.db` to the bottom. It's between `.env` and `.env.*`