### PR TITLE
Add issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -1,0 +1,34 @@
+name: "\U0001F41E Bug report"
+description: Report an issue
+body:
+  - type: markdown
+    attributes:
+      value: |
+        First thing first, thanks for reporting!
+  - type: textarea
+    id: bug-description
+    attributes:
+      label: Describe the bug
+      description: A clear and concise description of what the bug is. If you intend to submit a PR for this issue, tell us in the description. Thanks!
+      placeholder: Bug description
+    validations:
+      required: true
+  - type: textarea
+    id: screenshots
+    attributes:
+      label: Screenshots
+      description: If you have any screenshot that you need to share in order to better prove your point here's where you can do it.
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Reproduction
+      description: Please provide a link to a repo or better a stackblitz/replit that can reproduce the problem you ran into. This will speed up the fixing.
+      placeholder: Reproduction
+    validations:
+      required: true
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs
+      description: "Please include browser console and server logs around the time this bug occurred. Optional if provided reproduction. Please try not to insert an image but copy paste the log text."
+      render: shell

--- a/.github/ISSUE_TEMPLATE/feature_request.yaml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yaml
@@ -1,0 +1,23 @@
+name: "\U0001F4A1 Feature Request"
+description: Request a new feature
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thank you for taking the time to propose a new idea
+  - type: textarea
+    id: problem
+    attributes:
+      label: Describe the problem
+      description: Please provide a clear and concise description the problem this feature would solve. The more information you can provide here, the better.
+      placeholder: I would like to...
+    validations:
+      required: true
+  - type: textarea
+    id: solution
+    attributes:
+      label: Describe the proposed solution
+      description: Try to provide a description or a design of what you would like to be implemented
+      placeholder: I would like to see...
+    validations:
+      required: true


### PR DESCRIPTION
This simple pull request add two issue templates to guide the opener into a bug report or a feature request.

P.s. to get a glimpse of what it looks like you can visit my forked repository and try to open an issue.