### PR TITLE
Fix/Hack for no-unresolved

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -49,5 +49,6 @@ module.exports = {
 		'import/extensions': 0,
 		'import/no-extraneous-dependencies': 0,
 		'import/no-mutable-exports': 0,
+		'import/no-unresolved': 0,
 	},
 };


### PR DESCRIPTION
So this Fix/Hack technically turns it off, which in the end is not an issue, because we would get this error anyway:

```
Cannot find module '$apps/forms' or its corresponding type declarations.
```

If we try to import a module that isn't found.