### PR TITLE
Add typecheck to execute after lint

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -15,5 +15,6 @@ jobs:
     - run: npm ci
     - run: cp .env.example .env
     - run: npx svelte-kit sync
+    - run: npm run typecheck
     - run: npm run lint
     # - run: npm test

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -13,5 +13,7 @@ jobs:
       with:
         node-version: '16'
     - run: npm ci
+    - run: cp .env.example .env
+    - run: npx svelte-kit sync
     - run: npm run lint
     # - run: npm test

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,4 @@
 #!/usr/bin/env sh
 . "$(dirname -- "$0")/_/husky.sh"
 
-npm run lint
+npm run typecheck && npm run lint

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
 		"check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
 		"check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch",
 		"test:unit": "vitest",
-		"lint": "eslint --ext .js,.cjs,.ts,.svelte . && tsc --noEmit",
+		"lint": "eslint --ext .js,.cjs,.ts,.svelte .",
+		"typecheck": "tsc --noEmit",
 		"format": "prettier --plugin-search-dir . --check .",
 		"lint:fix": "eslint --ext .js,.cjs,.ts,.svelte . --fix",
 		"format:fix": "prettier --plugin-search-dir . --write ."

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
 		"check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
 		"check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch",
 		"test:unit": "vitest",
-		"lint": "eslint --ext .js,.cjs,.ts,.svelte .",
+		"lint": "eslint --ext .js,.cjs,.ts,.svelte . && tsc --noEmit",
 		"format": "prettier --plugin-search-dir . --check .",
 		"lint:fix": "eslint --ext .js,.cjs,.ts,.svelte . --fix",
 		"format:fix": "prettier --plugin-search-dir . --write ."


### PR DESCRIPTION
Adds a typecheck to execute after lint, I didn't now if we would like to have in a separated command, so I changed the `lint` command to execute the typecheck at the end. Let me know if we want separate the two commands.

For it to work with the types generated by svelte from .env files I needed to first:
`cp .env.example .env` then execute `npx svelte-kit sync` the last command generate the types necessaries so the typescript passes, here an example where I didn't do that.

![image](https://user-images.githubusercontent.com/4560552/218271416-a7a7542c-ed6d-46a5-a6fc-9c32cd71bb49.png)

And here after 

![image](https://user-images.githubusercontent.com/4560552/218271439-6158e5f4-237c-4544-ad9a-b5d1eb8a32aa.png)

fix #31