### PR TITLE
disable no-named-as-default fixes #37

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -49,6 +49,6 @@ module.exports = {
 		'import/extensions': 0,
 		'import/no-extraneous-dependencies': 0,
 		'import/no-mutable-exports': 0,
-    'import/no-named-as-default': 0,
+		'import/no-named-as-default': 0,
 	},
 };

--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -49,5 +49,6 @@ module.exports = {
 		'import/extensions': 0,
 		'import/no-extraneous-dependencies': 0,
 		'import/no-mutable-exports': 0,
+    'import/no-named-as-default': 0,
 	},
 };


### PR DESCRIPTION
This disables `import/no-named-as-default` rule which fixes #37 and #38 