### PR TITLE
Fix: no named export

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -18,6 +18,10 @@ module.exports = {
 			parserOptions: {
 				parser: '@typescript-eslint/parser',
 			},
+			rules: {
+				'import/no-named-as-default': 0,
+				'import/no-named-as-default-member': 0,
+			}
 		},
 	],
 	parserOptions: {
@@ -49,7 +53,6 @@ module.exports = {
 		'import/extensions': 0,
 		'import/no-extraneous-dependencies': 0,
 		'import/no-mutable-exports': 0,
-		'import/no-named-as-default': 0,
 		'import/no-duplicates': 0,
 		'import-no-duplicates-prefix-resolved-path/no-duplicates': [
 			'error',

--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -21,7 +21,7 @@ module.exports = {
 			rules: {
 				'import/no-named-as-default': 0,
 				'import/no-named-as-default-member': 0,
-			}
+			},
 		},
 	],
 	parserOptions: {


### PR DESCRIPTION
This PR moves the ESLint ignore rules to be applied only to *.svelte files.

Hopefully, this fixes No Named for good this time.