### PR TITLE
Remove remaining disable of @typescript-eslint/no-throw-literal for redirect

### DIFF
--- a/src/routes/(protected)/onboarding/+page.server.ts
+++ b/src/routes/(protected)/onboarding/+page.server.ts
@@ -5,7 +5,6 @@ import prismaClient from '../../../db.server';
 export const actions = {
 	default: async (event) => {
 		if (!event.locals.session?.user) {
-			// eslint-disable-next-line @typescript-eslint/no-throw-literal
 			throw redirect(302, '/');
 		}
 		// TODO: consume formdata, update user profile / settings
@@ -17,7 +16,6 @@ export const actions = {
 				onboarded: true,
 			},
 		});
-		// eslint-disable-next-line @typescript-eslint/no-throw-literal
 		throw redirect(302, '/');
 	},
 } satisfies Actions;

--- a/src/routes/+layout.server.ts
+++ b/src/routes/+layout.server.ts
@@ -7,7 +7,6 @@ export const load = (async ({ locals, route }) => {
 		!locals.session.user.settings.onboarded &&
 		route.id !== '/(protected)/onboarding'
 	) {
-		// eslint-disable-next-line @typescript-eslint/no-throw-literal
 		throw redirect(302, '/onboarding');
 	}
 	if (
@@ -15,7 +14,6 @@ export const load = (async ({ locals, route }) => {
 		locals.session.user.settings.onboarded &&
 		route.id === '/(protected)/onboarding'
 	) {
-		// eslint-disable-next-line @typescript-eslint/no-throw-literal
 		throw redirect(302, '/');
 	}
 	return {


### PR DESCRIPTION
Implemented with https://github.com/CodingGarden/listd/pull/57 we do not longer need to disable `@typescript-eslint/no-throw-literal` for `trhow redirect()`.

## What type of Pull Request is this?
- Code style update (formatting, renaming)

## What is the current behavior?
Some redirects still have the `@typescript-eslint/no-throw-literal` rule disabled.

## What is the new behavior?
Remaining disable of `@typescript-eslint/no-throw-literal` for redirects will be removed.
