### PR TITLE
Create SEO component to easily set title / meta information

### DIFF
--- a/src/lib/stores/SeoStore.ts
+++ b/src/lib/stores/SeoStore.ts
@@ -1,0 +1,6 @@
+import { writable } from 'svelte/store';
+
+export const seo = writable({
+	title: 'listd',
+	description: 'listd',
+});

--- a/src/routes/(protected)/onboarding/+page.svelte
+++ b/src/routes/(protected)/onboarding/+page.svelte
@@ -1,8 +1,10 @@
 <script lang="ts">
-	import { LL } from '$lib/i18n/i18n-svelte';
+	import Seo from '$/routes/SEO.svelte';
 	import { page } from '$app/stores';
+	import { LL } from '$lib/i18n/i18n-svelte';
 </script>
 
+<Seo title="Onboarding | listd" description="Onboarding page for listd" />
 <p>{$LL.onboarding.messages.main()}</p>
 <form class="pt-4" method="POST">
 	<label for="name" class="label">

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -1,16 +1,19 @@
 <script lang="ts">
-	import '@skeletonlabs/skeleton/themes/theme-crimson.css';
-	import '@skeletonlabs/skeleton/styles/all.css';
-	import '../app.postcss';
-	import { AppBar, AppShell } from '@skeletonlabs/skeleton';
-	import { setLocale } from '$lib/i18n/i18n-svelte.js';
 	import NavTrail from '$/routes/NavTrail.svelte';
+	import { setLocale } from '$lib/i18n/i18n-svelte.js';
+	import { seo } from '$lib/stores/SeoStore';
+	import { AppBar, AppShell } from '@skeletonlabs/skeleton';
+	import '@skeletonlabs/skeleton/styles/all.css';
+	import '@skeletonlabs/skeleton/themes/theme-crimson.css';
+	import '../app.postcss';
 	import type { LayoutData } from './$types.js';
+	import Seo from './SEO.svelte';
 
 	export let data: LayoutData;
 	setLocale(data.locale);
 </script>
 
+<Seo title={$seo.title} description={$seo.description} />
 <AppShell>
 	<svelte:fragment slot="header">
 		<AppBar>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -4,10 +4,15 @@
 	// import { IconBrandYoutube } from '@tabler/icons-svelte';
 	import { page } from '$app/stores';
 	import { LL } from '$lib/i18n/i18n-svelte';
-	import Seo from './SEO.svelte';
+
+	import { seo } from '$lib/stores/SeoStore';
+
+	seo.set({
+		title: 'listd',
+		description: 'listd',
+	});
 </script>
 
-<Seo title="listd" description="Welcome to listd!" />
 <div class="hero-container flex flex-col items-center justify-center p-4">
 	<p class="my-4 text-center">{$LL.tagline()}</p>
 	{#if $page.data.session}

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -2,10 +2,12 @@
 	import { signIn } from '@auth/sveltekit/client';
 	// TODO: fix load times...
 	// import { IconBrandYoutube } from '@tabler/icons-svelte';
-	import { LL } from '$lib/i18n/i18n-svelte';
 	import { page } from '$app/stores';
+	import { LL } from '$lib/i18n/i18n-svelte';
+	import Seo from './SEO.svelte';
 </script>
 
+<Seo title="listd" description="Welcome to listd!" />
 <div class="hero-container flex flex-col items-center justify-center p-4">
 	<p class="my-4 text-center">{$LL.tagline()}</p>
 	{#if $page.data.session}

--- a/src/routes/SEO.svelte
+++ b/src/routes/SEO.svelte
@@ -1,0 +1,9 @@
+<script lang="ts">
+	export let title = 'listd';
+	export let description = 'listd';
+</script>
+
+<svelte:head>
+	<title>{title}</title>
+	<meta name="description" content={description} />
+</svelte:head>

--- a/src/routes/SEO.svelte
+++ b/src/routes/SEO.svelte
@@ -13,4 +13,26 @@
 <svelte:head>
 	<title>{title}</title>
 	<meta name="description" content={description} />
+
+	<meta name="keywords" content="listd, youtube, channels, lists, app" />
+
+	<meta property="og:title" content={title} />
+	<meta property="og:description" content={description} />
+	<meta
+		property="og:image"
+		content="https://user-images.githubusercontent.com/1373867/221797903-42b3a12d-7d63-4284-b17a-83e2721a5d83.png"
+	/>
+	<meta property="og:url" content="https://listd.tv" />
+
+	<meta
+		property="twitter:card"
+		content="https://user-images.githubusercontent.com/1373867/221797903-42b3a12d-7d63-4284-b17a-83e2721a5d83.png"
+	/>
+	<meta property="twitter:url" content="https://listd.tv" />
+	<meta property="twitter:title" content={title} />
+	<meta property="twitter:description" content={description} />
+	<meta
+		property="twitter:image"
+		content="https://user-images.githubusercontent.com/1373867/221797903-42b3a12d-7d63-4284-b17a-83e2721a5d83.png"
+	/>
 </svelte:head>

--- a/src/routes/SEO.svelte
+++ b/src/routes/SEO.svelte
@@ -1,6 +1,13 @@
 <script lang="ts">
+	import { seo } from '$lib/stores/SeoStore';
+
 	export let title = 'listd';
 	export let description = 'listd';
+
+	seo.set({
+		title,
+		description,
+	});
 </script>
 
 <svelte:head>

--- a/src/routes/SEO.svelte
+++ b/src/routes/SEO.svelte
@@ -27,21 +27,9 @@
 
 	<meta property="og:title" content={title} />
 	<meta property="og:description" content={description} />
-	<meta
-		property="og:image"
-		content="https://user-images.githubusercontent.com/1373867/221797903-42b3a12d-7d63-4284-b17a-83e2721a5d83.png"
-	/>
 	<meta property="og:url" content="https://listd.tv" />
 
-	<meta
-		property="twitter:card"
-		content="https://user-images.githubusercontent.com/1373867/221797903-42b3a12d-7d63-4284-b17a-83e2721a5d83.png"
-	/>
 	<meta property="twitter:url" content="https://listd.tv" />
 	<meta property="twitter:title" content={title} />
 	<meta property="twitter:description" content={description} />
-	<meta
-		property="twitter:image"
-		content="https://user-images.githubusercontent.com/1373867/221797903-42b3a12d-7d63-4284-b17a-83e2721a5d83.png"
-	/>
 </svelte:head>

--- a/src/routes/SEO.svelte
+++ b/src/routes/SEO.svelte
@@ -1,12 +1,21 @@
 <script lang="ts">
 	import { seo } from '$lib/stores/SeoStore';
+	import { onMount } from 'svelte';
 
-	export let title = 'listd';
-	export let description = 'listd';
+	export const { title } = $seo;
+	export const { description } = $seo;
 
-	seo.set({
-		title,
-		description,
+	const loadSeo = () => {
+		seo.set({
+			title,
+			description,
+		});
+	};
+
+	loadSeo();
+
+	onMount(() => {
+		loadSeo();
 	});
 </script>
 


### PR DESCRIPTION
Created an SEO component to easily set the page title / meta information for each page in the application.

## What type of Pull Request is this?
**Delete all options except for the one that applies**
- Feature

## What is the current behavior?

You would have to manually work with the `<svelte:head>` on each page to set a title.

Issue Number: N/A

## What is the new behavior?

- Include the SEO component and set the props for `title` and `description`
- More props can be added in the future
- Additionally, more functionality can be added to the SEO component in one spot that can then be injected onto each page (analytics tags, more meta stuff, etc.)
