### PR TITLE
Fix invalid use of Nullish Coalescing

### DIFF
--- a/prisma/seeds/locales.ts
+++ b/prisma/seeds/locales.ts
@@ -22,7 +22,7 @@ export async function seed(prismaClient: PrismaClient) {
 			return {
 				id: locale.id.replaceAll('_', '-'),
 				formalName: locale.formalName,
-				commonName: locale.commonName ?? null,
+				commonName: locale.commonName || null,
 				nativeName: locale.nativeName,
 				languageCode,
 				countryCode,


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## What type of Pull Request is this?
- Bug fix

## What is the current behavior?

In the `seed/locales.ts` file, while seeding the database, the `??` operator is being used to compare the `locale.commonName`. However, this is an invalid use case, as seen below.

```ts
return {
  // ...
  commonName: locale.commonName ?? null, // Nullish Coalescing
  // ...
};
```

![image](https://user-images.githubusercontent.com/59444569/221602111-4871c2a8-5c29-404e-8256-84da0c512262.png)

As seen in the above screenshot, the above code fails to remove the empty `commonName` fields, and they still remain as empty strings (`""`).

This is because, the `??` operator is used to only explicitly check for `null` and `undefined`. Since `locale.commonName` is an empty string, that itself is returned by the operator.

Essentially, this means that `something ?? null` will always return the value of `something` (left hand value), unless `something` is `null/undefined`, in which case it will default to `null` (the right-hand value).


## What is the new behavior?


```ts
return {
  // ...
  commonName: locale.commonName || null, // Boolean OR
  // ...
};
```

![image](https://user-images.githubusercontent.com/59444569/221603054-bc40ab5e-af4e-43aa-9e73-8be34a741375.png)

Using the `||` operator fixes this and returns to expected behaviour.

## Other Information

* [Nullish Coalescing Operator](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Nullish_coalescing)

