### PR TITLE
Zero-effort type safety

### DIFF
--- a/src/routes/(protected)/create/+page.server.ts
+++ b/src/routes/(protected)/create/+page.server.ts
@@ -4,7 +4,6 @@ import { LL, setLocale } from '$lib/i18n/i18n-svelte';
 import { get } from 'svelte/store';
 import { z, ZodError } from 'zod';
 import prismaClient from '$lib/db.server';
-import type { Actions } from './$types';
 
 export async function load() {
 	return {
@@ -49,4 +48,4 @@ export const actions = {
 			return fail(400, { error: message });
 		}
 	},
-} satisfies Actions;
+};

--- a/src/routes/(protected)/create/+page.svelte
+++ b/src/routes/(protected)/create/+page.svelte
@@ -3,10 +3,9 @@
 	import { browser } from '$app/environment';
 	import { goto } from '$app/navigation';
 	import { LL } from '$lib/i18n/i18n-svelte';
-	import type { ActionData, PageData } from './$types';
 
-	export let data: PageData;
-	export let form: ActionData;
+	export let data;
+	export let form;
 
 	$: if (form?.success) {
 		const url = `/list/${form.listId}`;

--- a/src/routes/(protected)/onboarding/+page.server.ts
+++ b/src/routes/(protected)/onboarding/+page.server.ts
@@ -1,5 +1,4 @@
 import { redirect } from '@sveltejs/kit';
-import type { Actions } from './$types';
 import prismaClient from '../../../lib/db.server';
 
 export const actions = {
@@ -18,4 +17,4 @@ export const actions = {
 		});
 		throw redirect(302, '/');
 	},
-} satisfies Actions;
+};

--- a/src/routes/+layout.server.ts
+++ b/src/routes/+layout.server.ts
@@ -1,7 +1,6 @@
 import { redirect } from '@sveltejs/kit';
-import type { LayoutServerLoad } from './$types';
 
-export const load = (async ({ locals, route }) => {
+export const load = async ({ locals, route }) => {
 	if (
 		locals.session?.user &&
 		!locals.session.user.settings.onboarded &&
@@ -20,4 +19,4 @@ export const load = (async ({ locals, route }) => {
 		session: locals.session,
 		locale: locals.locale,
 	};
-}) satisfies LayoutServerLoad;
+};

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -6,10 +6,9 @@
 	import '@skeletonlabs/skeleton/themes/theme-crimson.css';
 	import '@skeletonlabs/skeleton/styles/all.css';
 	import '../app.postcss';
-	import type { LayoutData } from './$types.js';
 	import Seo from './SEO.svelte';
 
-	export let data: LayoutData;
+	export let data;
 	setLocale(data.locale);
 </script>
 

--- a/src/routes/+layout.ts
+++ b/src/routes/+layout.ts
@@ -1,9 +1,8 @@
 import { loadLocaleAsync } from '$lib/i18n/i18n-util.async';
-import type { LayoutLoad } from './$types';
 
-export const load = (async (event) => {
+export const load = async (event) => {
 	const { locale } = event.data;
 	await loadLocaleAsync(locale);
 
 	return event.data as App.Locals;
-}) satisfies LayoutLoad;
+};

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -4,9 +4,8 @@
 	import { page } from '$app/stores';
 	import { LL } from '$lib/i18n/i18n-svelte';
 	import { seo } from '$lib/stores/SeoStore';
-	import type { PageData } from './$types';
 
-	export let data: PageData;
+	export let data;
 
 	let loading = false;
 

--- a/src/routes/list/[id]/+page.svelte
+++ b/src/routes/list/[id]/+page.svelte
@@ -1,7 +1,5 @@
 <script lang="ts">
-	import type { PageData } from './$types';
-
-	export let data: PageData;
+	export let data;
 </script>
 
 <h2 class="font-bold">{data.list?.title}</h2>


### PR DESCRIPTION
Until recently you had to use type annotations for special SvelteKit values such as `data` and `load` imported from `./$types` which is no longer required if you read [Zero-effort type safety](https://svelte.dev/blog/zero-config-type-safety) because the language tools take care of it requiring only that you have the latest version of the Svelte extension.

https://user-images.githubusercontent.com/38083522/226173308-3991db98-d642-4a2c-869c-9d1f7131dbef.mp4

## What type of Pull Request is this?
- Refactoring (no functional changes, no API changes)


