### PR TITLE
Send YouTube API data to page using Streaming for `list/[id].svelte`

### DIFF
--- a/src/routes/list/[id]/+page.server.ts
+++ b/src/routes/list/[id]/+page.server.ts
@@ -5,6 +5,29 @@ import { youtube, youtube_v3 } from '@googleapis/youtube';
 import { error } from '@sveltejs/kit';
 import { get } from 'svelte/store';
 
+async function getVideos(channelIds: string[]) {
+	let videos: youtube_v3.Schema$SearchResult[] = [];
+
+	const client = youtube({
+		version: 'v3',
+		auth: config.YOUTUBE_API_KEY,
+	});
+
+	await channelIds.reduce(async (promise, channelId) => {
+		await promise;
+		const { data } = await client.search.list({
+			part: ['id', 'snippet'],
+			channelId,
+			type: ['video'],
+			maxResults: 10,
+		});
+		videos = videos.concat(data.items?.filter((i) => i) || []);
+	}, Promise.resolve());
+	videos.sort((a, b) => new Date(b.snippet?.publishedAt) - new Date(a.snippet?.publishedAt));
+
+	return videos;
+}
+
 export async function load({ params, locals }) {
 	try {
 		// TODO: handle visibility
@@ -20,27 +43,15 @@ export async function load({ params, locals }) {
 				},
 			},
 		});
-		const client = youtube({
-			version: 'v3',
-			auth: config.YOUTUBE_API_KEY,
-		});
 		const channelIds = list?.items.map((item) => item.meta.originId) || [];
-		let videos: youtube_v3.Schema$SearchResult[] = [];
-		await channelIds.reduce(async (promise, channelId) => {
-			await promise;
-			const { data } = await client.search.list({
-				part: ['id', 'snippet'],
-				channelId,
-				type: ['video'],
-				maxResults: 10,
-			});
-			videos = videos.concat(data.items?.filter((i) => i) || []);
-		}, Promise.resolve());
-		videos.sort((a, b) => new Date(b.snippet?.publishedAt) - new Date(a.snippet?.publishedAt));
+		console.log(channelIds);
+
 		if (list) {
 			return {
 				list,
-				videos,
+				streamed: {
+					videos: getVideos(channelIds),
+				},
 			};
 		}
 	} catch (e) {

--- a/src/routes/list/[id]/+page.server.ts
+++ b/src/routes/list/[id]/+page.server.ts
@@ -44,7 +44,6 @@ export async function load({ params, locals }) {
 			},
 		});
 		const channelIds = list?.items.map((item) => item.meta.originId) || [];
-		console.log(channelIds);
 
 		if (list) {
 			return {

--- a/src/routes/list/[id]/+page.svelte
+++ b/src/routes/list/[id]/+page.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { ProgressRadial } from '@skeletonlabs/skeleton';
 	import type { PageData } from './$types';
 
 	export let data: PageData;
@@ -10,21 +11,27 @@
 	<p>{item.name}</p>
 {/each} -->
 <div>
-	{#each data.videos as video}
-		<div class="card">
-			<!-- <img
-				class="w-full"
-				src={video.snippet?.thumbnails?.maxres?.url || video.snippet?.thumbnails?.default?.url}
-				alt={video.snippet?.title} /> -->
-			<iframe
-				class="w-full"
-				src={`https://www.youtube.com/embed/${video.id?.videoId}`}
-				title="YouTube video player"
-				frameborder="0"
-				allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
-				allowfullscreen />
-			<p class="text-center font-bold">{video.snippet?.channelTitle}</p>
-			<p class="text-center">{video.snippet?.title}</p>
-		</div>
-	{/each}
+	{#await data.streamed.videos}
+		<span class="grid w-full place-items-center p-4">
+			<ProgressRadial class="ml-2 h-8 w-8" stroke={100} />
+		</span>
+	{:then videos}
+		{#each videos as video}
+			<div class="card">
+				<!-- <img
+					class="w-full"
+					src={video.snippet?.thumbnails?.maxres?.url || video.snippet?.thumbnails?.default?.url}
+					alt={video.snippet?.title} /> -->
+				<iframe
+					class="w-full"
+					src={`https://www.youtube.com/embed/${video.id?.videoId}`}
+					title="YouTube video player"
+					frameborder="0"
+					allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+					allowfullscreen />
+				<p class="text-center font-bold">{video.snippet?.channelTitle}</p>
+				<p class="text-center">{video.snippet?.title}</p>
+			</div>
+		{/each}
+	{/await}
 </div>


### PR DESCRIPTION
This PR aims to resolve the long, blank load times of the `list/[id].svelte` route by streaming the data that is fetched from the YouTube API on the server side.

[Streaming in SvelteKit](https://svelte.dev/blog/streaming-snapshots-sveltekit) is a relatively new feature. TL;DR is that data that is returned in a promise as a nested field from the `load` function is not waited upon to be resolved before the page renders. This means that while the slow data is being fetched in the background, the rest of the page renders normally in a non-blocking way and the slow request can be awaited in the component with a loading state. This makes sure that even though you are making a slow request on the server, the user is not staring at a blank screen with no feedback.

## What type of Pull Request is this?
**Delete all options except for the one that applies**
- Other (please describe):
  - Performance enhancement

## What is the current behavior?

There is no feedback while the `list/[id].svelte` route is fetching the data from the YouTube API. 

Issue Number: N/A

## What is the new behavior?

- The video data is being streamed as a promise from the `load` function in `page.server.ts`.
- The `list/[id].svelte` page loads much more quickly than before.
- A loading spinner is shown on the page while the video data is being fetched from the YouTube API.

## Other information

I was running into some issues with the new zero-effort typesafety feature of SvelteKit with my setup, which was causing the `typecheck` step to fail. So, I had to use `--no-verify` to be able to make the commits.