### PR TITLE
Enable zero-effort type safety for other IDEs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -56,7 +56,6 @@
 				"tsx": "^3.12.5",
 				"typesafe-i18n": "^5.24.2",
 				"typescript": "^5.0.2",
-				"typescript-svelte-plugin": "^0.3.22",
 				"vite": "^4.2.0",
 				"vitest": "^0.29.3"
 			},
@@ -2508,12 +2507,6 @@
 				}
 			}
 		},
-		"node_modules/dedent-js": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/dedent-js/-/dedent-js-1.0.1.tgz",
-			"integrity": "sha512-OUepMozQULMLUmhxS95Vudo0jb0UchLimi3+pQ2plj61Fcy8axbP9hbiD4Sz6DPqn6XG3kfmziVfQ1rSys5AJQ==",
-			"dev": true
-		},
 		"node_modules/deep-eql": {
 			"version": "4.1.3",
 			"resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-4.1.3.tgz",
@@ -4751,15 +4744,6 @@
 				"get-func-name": "^2.0.0"
 			}
 		},
-		"node_modules/lower-case": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/lower-case/-/lower-case-2.0.2.tgz",
-			"integrity": "sha512-7fm3l3NAF9WfN6W3JOmf5drwpVqX78JtoGJ3A6W0a6ZnldM41w2fV5D490psKFTpMds8TJse/eHLFFsNHHjHgg==",
-			"dev": true,
-			"dependencies": {
-				"tslib": "^2.0.3"
-			}
-		},
 		"node_modules/lru-cache": {
 			"version": "6.0.0",
 			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
@@ -5069,16 +5053,6 @@
 			},
 			"engines": {
 				"node": "^10 || ^12 || >=14"
-			}
-		},
-		"node_modules/no-case": {
-			"version": "3.0.4",
-			"resolved": "https://registry.npmjs.org/no-case/-/no-case-3.0.4.tgz",
-			"integrity": "sha512-fgAN3jGAh+RoxUGZHTSOLJIqUc2wmoBwGR4tbpNAKmmovFoWq0OdRkb0VkldReO2a2iBT/OEulG9XSUc10r3zg==",
-			"dev": true,
-			"dependencies": {
-				"lower-case": "^2.0.2",
-				"tslib": "^2.0.3"
 			}
 		},
 		"node_modules/node-fetch": {
@@ -5403,16 +5377,6 @@
 			},
 			"engines": {
 				"node": ">=6"
-			}
-		},
-		"node_modules/pascal-case": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/pascal-case/-/pascal-case-3.1.2.tgz",
-			"integrity": "sha512-uWlGT3YSnK9x3BQJaOdcZwrnV6hPpd8jFH1/ucpiLRPh/2zCVJKS19E4GvYHvaCcACn3foXZ0cLB9Wrx1KGe5g==",
-			"dev": true,
-			"dependencies": {
-				"no-case": "^3.0.4",
-				"tslib": "^2.0.3"
 			}
 		},
 		"node_modules/path-exists": {
@@ -6841,20 +6805,6 @@
 				}
 			}
 		},
-		"node_modules/svelte2tsx": {
-			"version": "0.6.11",
-			"resolved": "https://registry.npmjs.org/svelte2tsx/-/svelte2tsx-0.6.11.tgz",
-			"integrity": "sha512-rRW/3V/6mcejYWmSqcHpmILOSPsOhLgkbKbrTOz82s2n8TywmIsqj2jYPsiL6HeGoUM/atiTD0YKguW4b7ECog==",
-			"dev": true,
-			"dependencies": {
-				"dedent-js": "^1.0.1",
-				"pascal-case": "^3.1.1"
-			},
-			"peerDependencies": {
-				"svelte": "^3.55",
-				"typescript": "^4.9.4 || ^5.0.0"
-			}
-		},
 		"node_modules/synckit": {
 			"version": "0.8.5",
 			"resolved": "https://registry.npmjs.org/synckit/-/synckit-0.8.5.tgz",
@@ -7259,16 +7209,6 @@
 			},
 			"engines": {
 				"node": ">=12.20"
-			}
-		},
-		"node_modules/typescript-svelte-plugin": {
-			"version": "0.3.22",
-			"resolved": "https://registry.npmjs.org/typescript-svelte-plugin/-/typescript-svelte-plugin-0.3.22.tgz",
-			"integrity": "sha512-HbBAoRlzyqsqBBuD9yOldAweFvXUA2GfVM/HPuTbnyAZTpLgjSV73oR9yg4661qZC27ug5vvDtZLvvBTBn4GVA==",
-			"dev": true,
-			"dependencies": {
-				"@jridgewell/sourcemap-codec": "^1.4.14",
-				"svelte2tsx": "~0.6.8"
 			}
 		},
 		"node_modules/ufo": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -56,6 +56,7 @@
 				"tsx": "^3.12.5",
 				"typesafe-i18n": "^5.24.2",
 				"typescript": "^5.0.2",
+				"typescript-svelte-plugin": "^0.3.22",
 				"vite": "^4.2.0",
 				"vitest": "^0.29.3"
 			},
@@ -2507,6 +2508,12 @@
 				}
 			}
 		},
+		"node_modules/dedent-js": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/dedent-js/-/dedent-js-1.0.1.tgz",
+			"integrity": "sha512-OUepMozQULMLUmhxS95Vudo0jb0UchLimi3+pQ2plj61Fcy8axbP9hbiD4Sz6DPqn6XG3kfmziVfQ1rSys5AJQ==",
+			"dev": true
+		},
 		"node_modules/deep-eql": {
 			"version": "4.1.3",
 			"resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-4.1.3.tgz",
@@ -4744,6 +4751,15 @@
 				"get-func-name": "^2.0.0"
 			}
 		},
+		"node_modules/lower-case": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/lower-case/-/lower-case-2.0.2.tgz",
+			"integrity": "sha512-7fm3l3NAF9WfN6W3JOmf5drwpVqX78JtoGJ3A6W0a6ZnldM41w2fV5D490psKFTpMds8TJse/eHLFFsNHHjHgg==",
+			"dev": true,
+			"dependencies": {
+				"tslib": "^2.0.3"
+			}
+		},
 		"node_modules/lru-cache": {
 			"version": "6.0.0",
 			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
@@ -5053,6 +5069,16 @@
 			},
 			"engines": {
 				"node": "^10 || ^12 || >=14"
+			}
+		},
+		"node_modules/no-case": {
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/no-case/-/no-case-3.0.4.tgz",
+			"integrity": "sha512-fgAN3jGAh+RoxUGZHTSOLJIqUc2wmoBwGR4tbpNAKmmovFoWq0OdRkb0VkldReO2a2iBT/OEulG9XSUc10r3zg==",
+			"dev": true,
+			"dependencies": {
+				"lower-case": "^2.0.2",
+				"tslib": "^2.0.3"
 			}
 		},
 		"node_modules/node-fetch": {
@@ -5377,6 +5403,16 @@
 			},
 			"engines": {
 				"node": ">=6"
+			}
+		},
+		"node_modules/pascal-case": {
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/pascal-case/-/pascal-case-3.1.2.tgz",
+			"integrity": "sha512-uWlGT3YSnK9x3BQJaOdcZwrnV6hPpd8jFH1/ucpiLRPh/2zCVJKS19E4GvYHvaCcACn3foXZ0cLB9Wrx1KGe5g==",
+			"dev": true,
+			"dependencies": {
+				"no-case": "^3.0.4",
+				"tslib": "^2.0.3"
 			}
 		},
 		"node_modules/path-exists": {
@@ -6805,6 +6841,20 @@
 				}
 			}
 		},
+		"node_modules/svelte2tsx": {
+			"version": "0.6.11",
+			"resolved": "https://registry.npmjs.org/svelte2tsx/-/svelte2tsx-0.6.11.tgz",
+			"integrity": "sha512-rRW/3V/6mcejYWmSqcHpmILOSPsOhLgkbKbrTOz82s2n8TywmIsqj2jYPsiL6HeGoUM/atiTD0YKguW4b7ECog==",
+			"dev": true,
+			"dependencies": {
+				"dedent-js": "^1.0.1",
+				"pascal-case": "^3.1.1"
+			},
+			"peerDependencies": {
+				"svelte": "^3.55",
+				"typescript": "^4.9.4 || ^5.0.0"
+			}
+		},
 		"node_modules/synckit": {
 			"version": "0.8.5",
 			"resolved": "https://registry.npmjs.org/synckit/-/synckit-0.8.5.tgz",
@@ -7209,6 +7259,16 @@
 			},
 			"engines": {
 				"node": ">=12.20"
+			}
+		},
+		"node_modules/typescript-svelte-plugin": {
+			"version": "0.3.22",
+			"resolved": "https://registry.npmjs.org/typescript-svelte-plugin/-/typescript-svelte-plugin-0.3.22.tgz",
+			"integrity": "sha512-HbBAoRlzyqsqBBuD9yOldAweFvXUA2GfVM/HPuTbnyAZTpLgjSV73oR9yg4661qZC27ug5vvDtZLvvBTBn4GVA==",
+			"dev": true,
+			"dependencies": {
+				"@jridgewell/sourcemap-codec": "^1.4.14",
+				"svelte2tsx": "~0.6.8"
 			}
 		},
 		"node_modules/ufo": {

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
 		"tsx": "^3.12.5",
 		"typesafe-i18n": "^5.24.2",
 		"typescript": "^5.0.2",
+		"typescript-svelte-plugin": "^0.3.22",
 		"vite": "^4.2.0",
 		"vitest": "^0.29.3"
 	},

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,7 +16,10 @@
 		"resolveJsonModule": true,
 		"skipLibCheck": true,
 		"sourceMap": true,
-		"strict": true
+		"strict": true,
+		"plugins": [{
+			"name": "typescript-svelte-plugin"
+		}]
 	},
 	"include": [
 		"./.svelte-kit/ambient.d.ts",


### PR DESCRIPTION
[Zero-effort type safety](https://svelte.dev/blog/zero-config-type-safety) is built into the Svelte VSCode extension. Those of us that use other IDEs though, need [typescript-svelte-plugin](https://github.com/sveltejs/language-tools/tree/master/packages/typescript-plugin) to get proper type completion in `+page.ts` and `+page.server.ts` files. This PR adds and configures that dev dependency.

## What type of Pull Request is this?

- Developer workflow enhancement

