### PR TITLE
Better debouncing for filtered list videos

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -35,6 +35,9 @@ module.exports = {
 		es2017: true,
 		node: true,
 	},
+	globals: {
+		NodeJS: true,
+	},
 	settings: {
 		'import/parsers': {
 			'@typescript-eslint/parser': ['.cjs', '.js', '.ts'],

--- a/src/routes/list/[id]/+layout.svelte
+++ b/src/routes/list/[id]/+layout.svelte
@@ -3,34 +3,37 @@
 	import YouTubeVideoEmbed from '$/lib/YouTubeVideoEmbed.svelte';
 	import ChannelCard from '$/lib/components/ChannelCard.svelte';
 	import { ProgressRadial } from '@skeletonlabs/skeleton';
-	import type { YouTubeVideoAPIResponse } from '$/lib/server/YouTubeAPI.js';
+	import type { YouTubeVideoAPIResponse } from '$/lib/server/YouTubeAPI';
 
 	export let data;
 
 	let filter = '';
 
-	let allVideos: YouTubeVideoAPIResponse[] = [];
-	let filteredVideos: YouTubeVideoAPIResponse[] = [];
-	let filterTimeout: number;
+	const filterVideos = (videos: YouTubeVideoAPIResponse[], filterString = '') => {
+		if (filterString === '') return videos;
 
-	const filterChanged = () => {
-		if (filter) {
-			clearTimeout(filterTimeout);
-			filterTimeout = setTimeout(() => {
-				const filterRegexp = new RegExp(filter, 'i');
-				filteredVideos = allVideos.filter(
-					(video) => video.description.match(filterRegexp) || video.title.match(filterRegexp)
-				);
-			}, 500) as unknown as number;
-		} else {
-			filteredVideos = allVideos;
-		}
+		const filterRegexp = new RegExp(filterString, 'i');
+		return videos.filter(
+			(video) => video.description.match(filterRegexp) || video.title.match(filterRegexp)
+		);
 	};
 
-	data.streamed.videos.then((result) => {
-		allVideos = result;
-		filteredVideos = allVideos;
-	});
+	let timeout: NodeJS.Timeout;
+	const handleKeyUp = (e: KeyboardEvent & { currentTarget: EventTarget & HTMLInputElement }) => {
+		const { value } = e.target as HTMLInputElement;
+		clearTimeout(timeout);
+
+		// immediately clear filter when input field is cleared
+		if (value === '') {
+			filter = value;
+			return;
+		}
+
+		// debounce filter
+		timeout = setTimeout(() => {
+			filter = value;
+		}, 500);
+	};
 </script>
 
 <slot />
@@ -56,13 +59,13 @@
 		<span class="grid w-full place-items-center p-4">
 			<ProgressRadial class="ml-2 h-8 w-8" stroke={100} />
 		</span>
-	{:then}
+	{:then videos}
 		<div class="my-4">
-			<input on:input={filterChanged} bind:value={filter} class="input" />
+			<input on:keyup={handleKeyUp} class="input" />
 		</div>
 		<div
 			class="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 2xl:grid-cols-5">
-			{#each filteredVideos as video}
+			{#each filterVideos(videos, filter) as video}
 				<YouTubeVideoEmbed
 					active={$page.params.videoid === video.videoId}
 					locale={data.locale}


### PR DESCRIPTION
This PR simplifies the de-bouncing of the video search filter on the list page.

## What type of Pull Request is this?

- Refactoring (no functional changes, no API changes)

## What is the current behavior?

* Currently, the videos that come in through a streamed promise from the server are awaited twice, once in the `script` tag and once in the actual template in the `#await` block. 
* On top of that, de-bouncing of the search filter and filtering of the array were combined, which introduced some unnecessary complexity.

## What is the new behavior?

* The de-bouncing of the search filter and  filtering of the videos is separated into their own functions. 
* Instead of filtering every time the query changes in a reactive statement, updating the search filter is handled by `on:keyup`. 
* Instead of awaiting `allVideos` in the template and maintaining a separate `filteredVideos` array, the videos are filtered inline directly in the `#await` block.

## Other information

This PR additionally adds a `globals` setting to `eslintrc.cjs` config for it to recognize `NodeJS` as a valid global type, which is where the `Timeout` type comes from.
