### PR TITLE
Added only render YouTubeVideoEmbed in the view port

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
 		"env-cmd": "^10.1.0",
 		"luxon": "^3.3.0",
 		"redis": "^4.6.6",
+		"svelte-inview": "^4.0.0",
 		"zod": "^3.21.4"
 	},
 	"license": "MIT",

--- a/src/lib/YouTubeVideoEmbed.svelte
+++ b/src/lib/YouTubeVideoEmbed.svelte
@@ -2,41 +2,57 @@
 	import { page } from '$app/stores';
 	import { formatNumberCompact, formatDuration, formatRelativeDate } from '$lib/utils';
 	import ViewCount from '$lib/ViewCount.svelte';
+	import { inview } from 'svelte-inview';
+	import type { ObserverEventDetails, Options } from 'svelte-inview';
 	import type { YouTubeVideoAPIResponse } from './server/YouTubeAPI';
 
 	export let locale: string;
 	export let active: boolean;
 	export let video: YouTubeVideoAPIResponse;
+
+	let isInView: boolean;
+	const options: Options = {
+		rootMargin: '50px',
+		unobserveOnEnter: true,
+	};
+
+	const handleChange = ({ detail }: CustomEvent<ObserverEventDetails>) => {
+		isInView = detail.inView;
+	};
 </script>
 
 <a
+	use:inview={options}
+	on:inview_change={handleChange}
 	href={`/list/${$page.params.id}/watch/${video.videoId}`}
 	class:variant-filled-primary={active}
 	class="card card-hover block cursor-pointer rounded-lg">
-	<div class="relative p-1">
-		<img
-			loading="lazy"
-			class="aspect-video w-full rounded-lg"
-			src={video.thumbnails.low}
-			alt={video.title} />
-		<!-- TODO: use icon library -->
-		<p class="absolute bottom-1 left-1 rounded-md bg-black bg-opacity-60 px-1.5 py-0.5 text-xs">
-			{formatNumberCompact(video.likes, locale)} 👍
-		</p>
-		<p class="absolute bottom-1 right-1 rounded-md bg-black bg-opacity-60 px-1.5 py-0.5">
-			{formatDuration(video.duration)}
-		</p>
-	</div>
-	<div class="m-2">
-		<p class="font-bold">{video.channelTitle}</p>
-		<div
-			class:dark:text-gray-400={!active}
-			class:light:text-gray-200={!active}
-			class="flex justify-between">
-			<ViewCount {locale} viewCount={video.viewCount} />
-			<span>{formatRelativeDate(video.publishedAt, locale)}</span>
+	{#if isInView}
+		<div class="relative p-1">
+			<img
+				loading="lazy"
+				class="aspect-video w-full rounded-lg"
+				src={video.thumbnails.low}
+				alt={video.title} />
+			<!-- TODO: use icon library -->
+			<p class="absolute bottom-1 left-1 rounded-md bg-black bg-opacity-60 px-1.5 py-0.5 text-xs">
+				{formatNumberCompact(video.likes, locale)} 👍
+			</p>
+			<p class="absolute bottom-1 right-1 rounded-md bg-black bg-opacity-60 px-1.5 py-0.5">
+				{formatDuration(video.duration)}
+			</p>
 		</div>
-		<!-- TODO: something better than ellipses... -->
-		<p class="my-2 line-clamp-2 break-words">{video.title}</p>
-	</div>
+		<div class="m-2">
+			<p class="font-bold">{video.channelTitle}</p>
+			<div
+				class:dark:text-gray-400={!active}
+				class:light:text-gray-200={!active}
+				class="flex justify-between">
+				<ViewCount {locale} viewCount={video.viewCount} />
+				<span>{formatRelativeDate(video.publishedAt, locale)}</span>
+			</div>
+			<!-- TODO: something better than ellipses... -->
+			<p class="my-2 line-clamp-2 break-words">{video.title}</p>
+		</div>
+	{/if}
 </a>


### PR DESCRIPTION
reduce the load time massiv depends of the amount video released by the channels


<!--- Please provide a general summary of your changes in the title above -->

## What type of Pull Request is this?
- Feature

## What is the current behavior?
Load all images/stuff of all videos of all channels in the list -> result massiv load/cpu time


## What is the new behavior?

Just rendering the most relevant videos,
when scrolling down more get loaded (since they are near the view port)



## Other information
add dependency svelte-inview

i try to keep pr small/focused,
so i didn't added a default height/width --> the scroll bar is "jumping" when scrolling down

also the option for svelte-inview could maybe optimize
