### PR TITLE
fix(YouTubeAPI): skip videos.list if we do not have any ids

### DIFF
--- a/src/lib/server/YouTubeAPI.ts
+++ b/src/lib/server/YouTubeAPI.ts
@@ -94,60 +94,63 @@ async function getAllVideos(
 		}
 		return all;
 	}, [] as string[]);
-	const { data: videoData } = await ytClient.videos.list({
-		part: [
-			'id',
-			'contentDetails',
-			'liveStreamingDetails',
-			'localizations',
-			'snippet',
-			'statistics',
-		],
-		id: ids,
-		maxResults: 50,
-	});
-	videoData.items?.forEach((video) => {
-		if (video && video.id) {
-			const videoResponse = {
-				thumbnails: {
-					high:
-						video.snippet?.thumbnails?.maxres?.url ||
-						video.snippet?.thumbnails?.standard?.url ||
-						video.snippet?.thumbnails?.high?.url ||
-						null,
-					low:
-						video.snippet?.thumbnails?.medium?.url ||
-						video.snippet?.thumbnails?.default?.url ||
-						null,
-				},
-				// TODO: i18n
-				title: video.snippet?.title || 'No Video Title',
-				description: video.snippet?.description || '',
-				videoId: video.id,
-				channelTitle: video.snippet?.channelTitle || 'No Channel Title',
-				channelId,
-				publishedAt: video.snippet?.publishedAt
-					? new Date(video.snippet?.publishedAt).getTime()
-					: Date.now(),
-				viewCount: parseYTNumber(video.statistics?.viewCount),
-				likes: parseYTNumber(video.statistics?.likeCount),
-				duration: video.contentDetails?.duration || 'PT0S',
-				upcoming: video.snippet?.liveBroadcastContent === 'upcoming',
-				livestream: video.liveStreamingDetails
-					? {
-							live: video.snippet?.liveBroadcastContent === 'live',
-							viewers: parseYTNumber(video.liveStreamingDetails.concurrentViewers),
-							liveChatId: video.liveStreamingDetails.activeLiveChatId || '',
-							actualStartAt: parseYTDate(video.liveStreamingDetails.actualStartTime),
-							scheduledStartAt: parseYTDate(video.liveStreamingDetails.scheduledStartTime),
-					  }
-					: null,
-			};
-			videoResponse.thumbnails.high = videoResponse.thumbnails.high?.replace('_live', '') || null;
-			videoResponse.thumbnails.low = videoResponse.thumbnails.low?.replace('_live', '') || null;
-			videos.push(videoResponse);
-		}
-	});
+
+	if (ids.length) {
+		const { data: videoData } = await ytClient.videos.list({
+			part: [
+				'id',
+				'contentDetails',
+				'liveStreamingDetails',
+				'localizations',
+				'snippet',
+				'statistics',
+			],
+			id: ids,
+			maxResults: 50,
+		});
+		videoData.items?.forEach((video) => {
+			if (video && video.id) {
+				const videoResponse = {
+					thumbnails: {
+						high:
+							video.snippet?.thumbnails?.maxres?.url ||
+							video.snippet?.thumbnails?.standard?.url ||
+							video.snippet?.thumbnails?.high?.url ||
+							null,
+						low:
+							video.snippet?.thumbnails?.medium?.url ||
+							video.snippet?.thumbnails?.default?.url ||
+							null,
+					},
+					// TODO: i18n
+					title: video.snippet?.title || 'No Video Title',
+					description: video.snippet?.description || '',
+					videoId: video.id,
+					channelTitle: video.snippet?.channelTitle || 'No Channel Title',
+					channelId,
+					publishedAt: video.snippet?.publishedAt
+						? new Date(video.snippet?.publishedAt).getTime()
+						: Date.now(),
+					viewCount: parseYTNumber(video.statistics?.viewCount),
+					likes: parseYTNumber(video.statistics?.likeCount),
+					duration: video.contentDetails?.duration || 'PT0S',
+					upcoming: video.snippet?.liveBroadcastContent === 'upcoming',
+					livestream: video.liveStreamingDetails
+						? {
+								live: video.snippet?.liveBroadcastContent === 'live',
+								viewers: parseYTNumber(video.liveStreamingDetails.concurrentViewers),
+								liveChatId: video.liveStreamingDetails.activeLiveChatId || '',
+								actualStartAt: parseYTDate(video.liveStreamingDetails.actualStartTime),
+								scheduledStartAt: parseYTDate(video.liveStreamingDetails.scheduledStartTime),
+						  }
+						: null,
+				};
+				videoResponse.thumbnails.high = videoResponse.thumbnails.high?.replace('_live', '') || null;
+				videoResponse.thumbnails.low = videoResponse.thumbnails.low?.replace('_live', '') || null;
+				videos.push(videoResponse);
+			}
+		});
+	}
 	if (data.nextPageToken) {
 		return getAllVideos(channelId, videos, data.nextPageToken);
 	}


### PR DESCRIPTION
## What type of Pull Request is this?

- Bug fix

## What is the current behavior?

When Youtube API returns list of 50 videos, that would not have valid IDs (after filtering undefineds) youtube videos.list would be called with empty id list, resulting in a ```No filter selected. Expected one of: myRating, id, chart```, and results with an server error and empty list in response/UI

## What is the new behavior?

When `ids` after filtering are empty, we skip call to youtube API and transformation of data.
Flow should continue with another recursion call or return from the function.


